### PR TITLE
Fix error when kick `generate_dataset.sh`

### DIFF
--- a/src/generate_dataset.py
+++ b/src/generate_dataset.py
@@ -79,7 +79,7 @@ def main(args):
         one_sample = training_data_samples[i]
         for task in tasks:
             datapoint = {}
-            datapoint['task'] = dataset + task
+            datapoint['task'] = args.dataset + task
             datapoint['data_id'] = i
             for pid in prompt[task]['seen']:
                 datapoint['instruction'] = prompt[task]['seen'][pid]['Input']

--- a/src/generate_dataset_eval.py
+++ b/src/generate_dataset_eval.py
@@ -66,7 +66,7 @@ def main(args):
         one_sample = data_samples[i]
         for task in tasks:
             datapoint = {}
-            datapoint['task'] = dataset + task
+            datapoint['task'] = args.dataset + task
             datapoint['instruction'] = prompt[task][prompt_info[0]][prompt_info[1]]['Input']
             datapoint['input'] = prompt[task][prompt_info[0]][prompt_info[1]]['Input'].format(**one_sample)
             datapoint['output'] = prompt[task][prompt_info[0]][prompt_info[1]]['Output'].format(**one_sample)


### PR DESCRIPTION
Hi, I tried your great OpenP5 project, but I had an error when I kick `generate_dataset.sh`.

The error log is like this.

```sh
Reindex data with random indexing method
get prompt from ./prompt.txt
load training data
there are 131413 samples in training data.
Traceback (most recent call last):
  File "/content/OpenP5/./src/generate_dataset.py", line 130, in <module>
    main(args)
  File "/content/OpenP5/./src/generate_dataset.py", line 82, in main
    datapoint['task'] = dataset + task
NameError: name 'dataset' is not defined

(more messeage...)
```

In my opinion, it seems there are a little misspelling, and I fixed this error in `generate_dataset.py` and `generate_dataset_eval.py`.

<details>
<summary>logs after my fix code</summary>

```sh
/content/OpenP5# ./generate_dataset.sh
Reindex data with random indexing method
get prompt from ./prompt.txt
load training data
there are 131413 samples in training data.
data constructed
there are 2628260 prompts in training data.
Reindex data with random indexing method
get prompt from ./prompt.txt
there are 22363 samples in validation data.
['seen', '0']
data constructed

(more message...)
```

</details>

Could you check this pr, please?
