### PR TITLE
fix error when kick ML1M_t5_sequential.sh

### DIFF
--- a/command/ML1M_t5_sequential.sh
+++ b/command/ML1M_t5_sequential.sh
@@ -1,1 +1,9 @@
+#!/bin/bash
+
+dir_path="../log/ML1M/"
+
+if [ ! -d "$dir_path" ]; then
+    mkdir -p "$dir_path"
+fi
+
 CUDA_VISIBLE_DEVICES=2,3 torchrun --nproc_per_node=2 --master_port=1234 ../src/train.py --item_indexing sequential --tasks sequential,straightforward --datasets ML1M --epochs 10 --batch_size 128 --backbone t5-small --cutoff 1024 > ../log/ML1M/ML1M_t5_sequential.log


### PR DESCRIPTION
Hi, I tried your great OpenP5 project, but I had an error when I kick `ML1M_t5_sequential.sh` as written in README.

```
$ ./ML1M_t5_sequential.sh
./ML1M_t5_sequential.sh: line 1: ../log/ML1M/ML1M_t5_sequential.log: No such file or directory
```

In my opinion, it seems that this script needs `../log/ML1M/` directory, and I fixed this error in `ML1M_t5_sequential.sh`.

<details>

<summary>logs after my fix code</summary>

```
$ ./ML1M_t5_sequential.sh
WARNING:torch.distributed.run:
*****************************************
Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed.
*****************************************
/opt/conda/lib/python3.10/site-packages/torch/cuda/__init__.py:546: UserWarning: Can't initialize NVML
  warnings.warn("Can't initialize NVML")
/opt/conda/lib/python3.10/site-packages/torch/cuda/__init__.py:546: UserWarning: Can't initialize NVML
  warnings.warn("Can't initialize NVML")
Downloading data files: 100%|�������������������������������������������������������� 1/1 [00:00<00:00, 9157.87it/s]                                  | 0/1 [00:00<?, ?it/s]
Extracting data files: 100%|��������������������������������������������������������� 1/1 [00:00<00:00, 949.80it/s]                                   | 0/1 [00:00<?, ?it/s]
Generating train split: 0 examples [00:00, ? examples/s]

(more messages...)
```
</details>

Could you check this pr, please?