### PR TITLE
Fix error no `task alternating_optim` argument

### DIFF
--- a/command/ML1M_t5_sequential.sh
+++ b/command/ML1M_t5_sequential.sh
@@ -1,1 +1,9 @@
+#!/bin/bash
+
+dir_path="../log/ML1M/"
+
+if [ ! -d "$dir_path" ]; then
+    mkdir -p "$dir_path"
+fi
+
 CUDA_VISIBLE_DEVICES=2,3 torchrun --nproc_per_node=2 --master_port=1234 ../src/train.py --item_indexing sequential --tasks sequential,straightforward --datasets ML1M --epochs 10 --batch_size 128 --backbone t5-small --cutoff 1024 > ../log/ML1M/ML1M_t5_sequential.log

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -60,6 +60,7 @@ def parse_args(parser):
     parser.add_argument("--batch_size", type=int, default=32, help="batch size")
     parser.add_argument("--eval_batch_size", type=int, default=32, help="the batch size for evaluation")
     parser.add_argument("--group_task_in_batch", type=int, default=1, help='Whether group data for one task in the batch. If so, use customized sampler')
+    parser.add_argument("--task_alternating_optim", type=int, default=0, help='Whether use alternating optimizations')
     
     # arguments related to trainer
     parser.add_argument("--optim", type=str, default='adamw_torch', help='The name of the optimizer')

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -249,4 +249,3 @@ def check_task_prompt(prompt_templates, task_list):
     for task in task_list:
         assert task in prompt_templates, f"No prompt for {task} task"
         
-        


### PR DESCRIPTION
Hi,

When I kick `command/ML1M_t5_sequential.sh`, I got error like below.

```
~/OpenP5/command$ ./ML1M_t5_sequential.sh
WARNING:torch.distributed.run:
*****************************************
Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed.
*****************************************
/opt/conda/lib/python3.10/site-packages/torch/cuda/__init__.py:546: UserWarning: Can't initialize NVML
  warnings.warn("Can't initialize NVML")
/opt/conda/lib/python3.10/site-packages/torch/cuda/__init__.py:546: UserWarning: Can't initialize NVML
  warnings.warn("Can't initialize NVML")
Traceback (most recent call last):
  File "/home/takuya/OpenP5/command/../src/train.py", line 275, in <module>
    main()
  File "/home/takuya/OpenP5/command/../src/train.py", line 159, in main
    if args.task_alternating_optim == 1:
AttributeError: 'Namespace' object has no attribute 'task_alternating_optim'
Traceback (most recent call last):
  File "/home/takuya/OpenP5/command/../src/train.py", line 275, in <module>
    main()
  File "/home/takuya/OpenP5/command/../src/train.py", line 159, in main
    if args.task_alternating_optim == 1:
AttributeError: 'Namespace' object has no attribute 'task_alternating_optim'
ERROR:torch.distributed.elastic.multiprocessing.api:failed (exitcode: 1) local_rank: 0 (pid: 3635) of binary: /opt/conda/bin/python3.10
Traceback (most recent call last):
  File "/opt/conda/bin/torchrun", line 8, in <module>
    sys.exit(main())
  File "/opt/conda/lib/python3.10/site-packages/torch/distributed/elastic/multiprocessing/errors/__init__.py", line 346, in wrapper
    return f(*args, **kwargs)
  File "/opt/conda/lib/python3.10/site-packages/torch/distributed/run.py", line 794, in main
    run(args)
  File "/opt/conda/lib/python3.10/site-packages/torch/distributed/run.py", line 785, in run
    elastic_launch(
  File "/opt/conda/lib/python3.10/site-packages/torch/distributed/launcher/api.py", line 134, in __call__
    return launch_agent(self._config, self._entrypoint, list(args))
  File "/opt/conda/lib/python3.10/site-packages/torch/distributed/launcher/api.py", line 250, in launch_agent
    raise ChildFailedError(
torch.distributed.elastic.multiprocessing.errors.ChildFailedError:
============================================================
../src/train.py FAILED
------------------------------------------------------------
Failures:
[1]:
  time      : 2023-11-03_12:14:13
  host      : instance-2.c.wantedly-individual-takuya.internal
  rank      : 1 (local_rank: 1)
  exitcode  : 1 (pid: 3636)
  error_file: <N/A>
  traceback : To enable traceback see: https://pytorch.org/docs/stable/elastic/errors.html
------------------------------------------------------------
Root Cause (first observed failure):
[0]:
  time      : 2023-11-03_12:14:13
  host      : instance-2.c.wantedly-individual-takuya.internal
  rank      : 0 (local_rank: 0)
  exitcode  : 1 (pid: 3635)
  error_file: <N/A>
  traceback : To enable traceback see: https://pytorch.org/docs/stable/elastic/errors.html
============================================================
```

I think `src/utils/utils.py` should have argument `task_alternating_optim`.
When I fix it, it seems that it runs successfully.

<details>

<summary>logs after my fix code</summary>

```
$ ./ML1M_t5_sequential.sh
WARNING:torch.distributed.run:
*****************************************
Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed.
*****************************************
/opt/conda/lib/python3.10/site-packages/torch/cuda/__init__.py:546: UserWarning: Can't initialize NVML
  warnings.warn("Can't initialize NVML")
/opt/conda/lib/python3.10/site-packages/torch/cuda/__init__.py:546: UserWarning: Can't initialize NVML
  warnings.warn("Can't initialize NVML")
Map:   0%|▎                                                                                                             | 45917/19629820 [00:21<2:27:02, 2219.79 examples/s]
(more messages...)
```
</details>

Could you check this pr, please?